### PR TITLE
Fix serverless deployment issue

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,6 @@
         "@elysiajs/swagger": "^1.3.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
-        "@keyv/compress-lz4": "^1.0.0",
         "@mui/icons-material": "^7.1.1",
         "@mui/material": "^7.1.1",
         "@prisma/extension-accelerate": "^2.0.1",
@@ -70,31 +69,18 @@
 
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
 
-    "@antoniomuso/lz4-napi-android-arm-eabi": ["@antoniomuso/lz4-napi-android-arm-eabi@2.8.0", "", { "os": "android", "cpu": "arm" }, "sha512-j1AF1SXOpgiEUxF74cOQLPTwAB9hvR4TqoHJR/ClzP1iWrWZCm6P6tNLy1P1KSn1x3ATGyiTHJqn1V5GvimJvQ=="],
 
-    "@antoniomuso/lz4-napi-android-arm64": ["@antoniomuso/lz4-napi-android-arm64@2.8.0", "", { "os": "android", "cpu": "arm64" }, "sha512-lWWPa65eDfhopwFx77bzEUClMHC0WBmy1mOb6LaLRBuT8FaBIscwanb93Zmz1VSbrHTg3sgW3qbGYCEz/WP0Lg=="],
 
-    "@antoniomuso/lz4-napi-darwin-arm64": ["@antoniomuso/lz4-napi-darwin-arm64@2.8.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-vJPGIBBwQKfYW8bp/WZBvSuNxiTHAe5RcQY44If9/wzo+uSNbbglCJOBSJurvRHEVFPREBWlVtXhTVP4qCxZdQ=="],
 
-    "@antoniomuso/lz4-napi-darwin-x64": ["@antoniomuso/lz4-napi-darwin-x64@2.8.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-DK+jjKKmQtZT80UC08z2Uz08G3QJyZijL8BjyxsMHNXEPHp+bYbWWM6esecadwbl61zrHIiiHx4m7WTLaC1ijA=="],
 
-    "@antoniomuso/lz4-napi-freebsd-x64": ["@antoniomuso/lz4-napi-freebsd-x64@2.8.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-4etI4CH+maAMfhRoSn2vGPcPOVA5ASFkeowfOL0BxKGN6QrFtRwzACGl6f/61tcmdDV7mypaw///6VXL3o2ksQ=="],
 
-    "@antoniomuso/lz4-napi-linux-arm-gnueabihf": ["@antoniomuso/lz4-napi-linux-arm-gnueabihf@2.8.0", "", { "os": "linux", "cpu": "arm" }, "sha512-PwWXPXCEmN/PYpqiKaxxbqLhPFtS05YYaFjmcZ55PXSpb/Okq/aO93+JCUuB5+zCMeKBfv3SGDaxN62moEGr5w=="],
 
-    "@antoniomuso/lz4-napi-linux-arm64-gnu": ["@antoniomuso/lz4-napi-linux-arm64-gnu@2.8.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-ky5Av50tnYLZTMcCFK2r/yQng7PRvdTS6J3FMiFsaMQbOgieKa0Ll61MMIHWrixhJSHW0oOFbsWIcr06xO7Gdg=="],
 
-    "@antoniomuso/lz4-napi-linux-arm64-musl": ["@antoniomuso/lz4-napi-linux-arm64-musl@2.8.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-lc4HCcmbvvXggoeb3CeGVhjBQrcaoGsIUUkWVaWdBOJTggjLCj67S7xEcqwFCeJQlGT7Ak36CLTbAbKWDRMMDA=="],
 
-    "@antoniomuso/lz4-napi-linux-x64-gnu": ["@antoniomuso/lz4-napi-linux-x64-gnu@2.8.0", "", { "os": "linux", "cpu": "x64" }, "sha512-iyaES5Gm3Bhxu+G9CzUlGNWCSzquyoKGne1T7kxeN1FnQa4vSVbX+QvN/3NueSNhoErqy3Eh3cdkoSyPj9fJZg=="],
 
-    "@antoniomuso/lz4-napi-linux-x64-musl": ["@antoniomuso/lz4-napi-linux-x64-musl@2.8.0", "", { "os": "linux", "cpu": "x64" }, "sha512-/EmFdbvT2LPcxDGalqvQXmSplGNmNySseWN7XBG2Z7AYq6kEobPZOU1+9z1YjmrR2LDQRO0wBZNXYGHRdKuMjg=="],
 
-    "@antoniomuso/lz4-napi-win32-arm64-msvc": ["@antoniomuso/lz4-napi-win32-arm64-msvc@2.8.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-m4ZgbxnUeNJDC861k+qc+zFjbYATgIx7xevyTavoAr04Apv9rBadrk9VmzUyqjjqTEpyI9OEyoFsIqb8hyCZ6w=="],
 
-    "@antoniomuso/lz4-napi-win32-ia32-msvc": ["@antoniomuso/lz4-napi-win32-ia32-msvc@2.8.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-uMOirYEGNdg2GYD2wpRg6C5tv/D3S17XHifjELoYGmTdE0p31/yhcjN7o/rRNze5aEoo72eEjwQAruZi4SYPgQ=="],
 
-    "@antoniomuso/lz4-napi-win32-x64-msvc": ["@antoniomuso/lz4-napi-win32-x64-msvc@2.8.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Vm1jrS59bB9tRBIuuDff6m6wTIrfl212FadFprI3QZpiErlSO0FKutTmv+DcMJ3sEkfXpMWR98D5cVBmFihW/g=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
 
@@ -350,7 +336,6 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
 
-    "@keyv/compress-lz4": ["@keyv/compress-lz4@1.0.0", "", { "dependencies": { "@keyv/serialize": "^1.0.2", "keyv": "^5.2.3", "lz4-napi": "^2.8.0" } }, "sha512-Da7KJn6ibksmU9jp+mOAMA3DlNX/TNd06JF4Y1Ya1ISlO+b5iilcXiGGWJvfzFv10ym70WuGPfMeJYWEt5LGTQ=="],
 
     "@keyv/serialize": ["@keyv/serialize@1.0.3", "", { "dependencies": { "buffer": "^6.0.3" } }, "sha512-qnEovoOp5Np2JDGonIDL6Ayihw0RhnRh6vxPuHo4RDn1UOzwEo4AeIfpL6UGIrsceWrCMiVPgwRjbHu4vYFc3g=="],
 
@@ -1216,7 +1201,6 @@
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
-    "lz4-napi": ["lz4-napi@2.8.0", "", { "dependencies": { "@node-rs/helper": "^1.3.3" }, "optionalDependencies": { "@antoniomuso/lz4-napi-android-arm-eabi": "2.8.0", "@antoniomuso/lz4-napi-android-arm64": "2.8.0", "@antoniomuso/lz4-napi-darwin-arm64": "2.8.0", "@antoniomuso/lz4-napi-darwin-x64": "2.8.0", "@antoniomuso/lz4-napi-freebsd-x64": "2.8.0", "@antoniomuso/lz4-napi-linux-arm-gnueabihf": "2.8.0", "@antoniomuso/lz4-napi-linux-arm64-gnu": "2.8.0", "@antoniomuso/lz4-napi-linux-arm64-musl": "2.8.0", "@antoniomuso/lz4-napi-linux-x64-gnu": "2.8.0", "@antoniomuso/lz4-napi-linux-x64-musl": "2.8.0", "@antoniomuso/lz4-napi-win32-arm64-msvc": "2.8.0", "@antoniomuso/lz4-napi-win32-ia32-msvc": "2.8.0", "@antoniomuso/lz4-napi-win32-x64-msvc": "2.8.0" } }, "sha512-mvJVO3AlJCr5EACl1JxHUA3aMej77bjo53JXyNZXeB1HQLjWntjJSXUYLUwyUuB8NT7GkyPdUbzNYi0UDcdUJg=="],
 
     "magic-string": ["magic-string@0.30.17", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0" } }, "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA=="],
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "@elysiajs/swagger": "^1.3.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
-    "@keyv/compress-lz4": "^1.0.0",
     "@mui/icons-material": "^7.1.1",
     "@mui/material": "^7.1.1",
     "@prisma/extension-accelerate": "^2.0.1",

--- a/src/libs/better-auth/auth.ts
+++ b/src/libs/better-auth/auth.ts
@@ -1,4 +1,3 @@
-import KeyvLz4 from '@keyv/compress-lz4'
 import { betterAuth } from 'better-auth'
 import { prismaAdapter } from 'better-auth/adapters/prisma'
 import { bearer, openAPI } from 'better-auth/plugins'
@@ -8,7 +7,6 @@ import { env } from '@/src/env/server'
 import { appDB } from '@/src/libs/prisma'
 
 const keyv = new Keyv({
-  compression: new KeyvLz4(),
   namespace: 'better-auth',
   store: new Map(),
   useKeyPrefix: false,


### PR DESCRIPTION
## Summary
- remove `KeyvLz4` usage so `lz4-napi` is not required
- drop `@keyv/compress-lz4` dependency
- update lockfile

## Testing
- `bun x eslint . --max-warnings=0` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854578e26148322be0f78c3be0510a4